### PR TITLE
Change URLs in library.properties to http://

### DIFF
--- a/Blinky/library.properties
+++ b/Blinky/library.properties
@@ -5,5 +5,5 @@ maintainer=CNC LAB <info@cnclablb.com>
 sentence=Library code for blinking LED from CNC LAB
 paragraph=The Blinky library provides easy blinking LED timing management suitable for error codes and other user interfacing purposes.
 category=Display
-url=https://www.cnclablb.com
+url=http://www.cnclablb.com
 architectures=*

--- a/Debouncer/library.properties
+++ b/Debouncer/library.properties
@@ -5,5 +5,5 @@ maintainer=CNC LAB <info@cnclablb.com>
 sentence=Library code for simple boolean debouncing without delay from CNC LAB
 paragraph=This library provides a simple debouncing routine suitable for any boolean value debouncing purposes.
 category=Signal Input/Output
-url=https://www.cnclablb.com
+url=http://www.cnclablb.com
 architectures=*

--- a/ErrorManager/library.properties
+++ b/ErrorManager/library.properties
@@ -5,5 +5,5 @@ maintainer=CNC LAB <info@cnclablb.com>
 sentence=Library custom error status and codes management from CNC LAB
 paragraph=This library provides a simple error management class suitable for all UI applications.
 category=Display
-url=https://www.cnclablb.com
+url=http://www.cnclablb.com
 architectures=*

--- a/Vector/library.properties
+++ b/Vector/library.properties
@@ -5,5 +5,5 @@ maintainer=CNC LAB <info@cnclablb.com>
 sentence=Library for byte array vector from CNC LAB
 paragraph=This library provides a Vector class for easier byte array manipulation and passing to other functions as input parameter.
 category=Data Storage
-url=https://www.cnclablb.com
+url=http://www.cnclablb.com
 architectures=*


### PR DESCRIPTION
Something is wrong with www.cnclablb.com's https:// so the previous URL is blocked by the browser.